### PR TITLE
change to icon_style() function

### DIFF
--- a/custom-post-type.php
+++ b/custom-post-type.php
@@ -315,19 +315,18 @@ class Bamboo_Custom_Post_Type
 
 
 	/**
-	 * Icon Style
-	 * ========================================================================
-	 * @param  {null}
-	 * @return {output} html
-	 */
-	public function icon_style() { ?>
-	<style rel="stylesheet" media="screen">
-		#adminmenu .menu-icon-<?php echo $this->name; ?> div.wp-menu-image:before {
-			font-family: 'FontAwesome' !important;
-			content: '\<?php echo $this->icon; ?>';
-		}
-	</style>
-	<?php }
+   	* Icon Style
+   	* ========================================================================
+   	* @param  {null}
+   	* @return {output} html
+   	*/
+  	public function icon_style() { ?>
+    		<style rel="stylesheet" media="screen">
+    			#adminmenu .menu-icon-<?php echo strtolower(str_replace(' ', '', $this->name) ) ; ?> div.wp-menu-image:before {
+      				content: '\<?php echo $this->icon; ?>';
+    			}
+    		</style>
+  	<?php }
 
 
 


### PR DESCRIPTION
This change removes the font-awesome dependency and allows the use of wordpress core unicodes such as 'f105' - page.
you may wish to tweak it or add an additional parameter to specify wp (wordpress) or fa (font-awesome).

I also fixed an issue with the style declaration for both single and multiple word post names. 
